### PR TITLE
Fix too much memory in elastic search and use recent lwan version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - "xpack.security.enabled=false"
       - "xpack.security.transport.ssl.enabled=false"
       - "xpack.security.http.ssl.enabled=false"
+      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
     ports:
       - "19200:9200"
       - "9300:9300"
@@ -92,7 +93,7 @@ services:
       - "15672:15672"
       - "5672:5672"
   fake_api:
-    image: ghcr.io/lpereira/lwan:latest
+    image: ghcr.io/lpereira/lwan:master
     volumes:
       - ./data:/wwwroot
     ports:


### PR DESCRIPTION
By default elastic search takes half of the machine detected memory, but it can be limited with the environment option:
```bash
ES_JAVA_OPTS=-Xms1024m -Xmx1024m
```
(that is setting the limits to 1Gb) 

Also I had issues in my machine with the `latest` **lwan** version (it ate all my machine memory.. did not know why), and looking at the project info: https://github.com/lpereira/lwan/pkgs/container/lwan , it instructs to use the `master` version instead. After using it, my memory issues with it have gone away. 
