### PR TITLE
Test load folder files

### DIFF
--- a/config/krakend/extended/krakend.tmpl
+++ b/config/krakend/extended/krakend.tmpl
@@ -17,6 +17,16 @@
     }
   ],
   "endpoints": [
+      {{ range .gatherendpoints }}
+          {{$filename := .name}}
+
+          {{ range $n, $k := until (int .num) }}
+          {
+            "$ref": "./templates/{{ $filename }}#/endpoints/{{ $n }}"
+          }
+          ,
+          {{ end }}
+      {{ end }}
       {{ template "endpoints_req_resp_transformations.json" . }},
       {{ template "endpoints_authentication.json" . }},
       {{ template "endpoints_traffic_management.json" . }},

--- a/config/krakend/extended/settings/endpoints_collection.json
+++ b/config/krakend/extended/settings/endpoints_collection.json
@@ -8,5 +8,14 @@
             "name": "ref_collection_b.json",
             "num": 3
         }
-    ]
+    ],
+    "futurama": {
+        "zoidberg": "doctor",
+        "bender": "robot"
+    },
+    "simpsons": {
+        "homer": "father",
+        "marge": "mother",
+        "bart": "son"
+    }
 }

--- a/config/krakend/extended/settings/endpoints_collection.json
+++ b/config/krakend/extended/settings/endpoints_collection.json
@@ -1,0 +1,12 @@
+{
+    "gatherendpoints": [
+        { 
+            "name": "ref_collection_a.json",
+            "num": 2
+        },
+        {
+            "name": "ref_collection_b.json",
+            "num": 3
+        }
+    ]
+}

--- a/config/krakend/extended/templates/ref_collection_a.json
+++ b/config/krakend/extended/templates/ref_collection_a.json
@@ -1,7 +1,7 @@
 {
     "endpoints": [
         {
-            "endpoint": "/public/from_a_file/first",
+            "endpoint": "/public/from_a_file/first/{{.futurama.zoidberg}}",
             "backend": [
                 {
                     "url_pattern": "/static/hotels/1.json"
@@ -9,7 +9,7 @@
             ]
         },
         {
-            "endpoint": "/public/from_a_file/second",
+            "endpoint": "/public/from_a_file/second/{{.futurama.bender}}",
             "backend": [
                 {
                     "url_pattern": "/static/hotels/1.json"

--- a/config/krakend/extended/templates/ref_collection_a.json
+++ b/config/krakend/extended/templates/ref_collection_a.json
@@ -1,0 +1,20 @@
+{
+    "endpoints": [
+        {
+            "endpoint": "/public/from_a_file/first",
+            "backend": [
+                {
+                    "url_pattern": "/static/hotels/1.json"
+                }
+            ]
+        },
+        {
+            "endpoint": "/public/from_a_file/second",
+            "backend": [
+                {
+                    "url_pattern": "/static/hotels/1.json"
+                }
+            ]
+        }
+    ]
+}

--- a/config/krakend/extended/templates/ref_collection_b.json
+++ b/config/krakend/extended/templates/ref_collection_b.json
@@ -1,7 +1,7 @@
 {
     "endpoints": [
         {
-            "endpoint": "/public/from_b_file/first",
+            "endpoint": "/public/from_b_file/first/{{.simpsons.homer}}",
             "backend": [
                 {
                     "url_pattern": "/static/hotels/1.json"
@@ -9,7 +9,7 @@
             ]
         },
         {
-            "endpoint": "/public/from_b_file/second",
+            "endpoint": "/public/from_b_file/second/{{.simpsons.marge}}",
             "backend": [
                 {
                     "url_pattern": "/static/hotels/1.json"
@@ -17,7 +17,7 @@
             ]
         },
         {
-            "endpoint": "/public/from_b_file/third",
+            "endpoint": "/public/from_b_file/third/{{.simpsons.bart}}",
             "backend": [
                 {
                     "url_pattern": "/static/hotels/1.json"

--- a/config/krakend/extended/templates/ref_collection_b.json
+++ b/config/krakend/extended/templates/ref_collection_b.json
@@ -1,0 +1,28 @@
+{
+    "endpoints": [
+        {
+            "endpoint": "/public/from_b_file/first",
+            "backend": [
+                {
+                    "url_pattern": "/static/hotels/1.json"
+                }
+            ]
+        },
+        {
+            "endpoint": "/public/from_b_file/second",
+            "backend": [
+                {
+                    "url_pattern": "/static/hotels/1.json"
+                }
+            ]
+        },
+        {
+            "endpoint": "/public/from_b_file/third",
+            "backend": [
+                {
+                    "url_pattern": "/static/hotels/1.json"
+                }
+            ]
+        }
+    ]
+}

--- a/config/krakend/fc_config.local.json
+++ b/config/krakend/fc_config.local.json
@@ -8,6 +8,7 @@
         "paths": [
             "./extended/settings/root.vars.json",
             "./extended/settings/root.local.vars.json",
+            "./extended/settings/endpoints_collection.json",
             "./extended/settings/all_environments",
             "./extended/root.local.vars.json"
         ]


### PR DESCRIPTION
This is a showcase of how to use flexible config to use `$ref` instead of `template` to collect endpoint definitions from a set of files in the **templates** folder. 

 

In order to be used with ref, the files **MUST** have a valid JSON object inside, somthing like this:

```json
{
    "endpoints": [
        {
            "endpoint": "/public/from_a_file/first/{{.futurama.zoidberg}}",
            "backend": [
                {
                    "url_pattern": "/static/hotels/1.json"
                }
            ]
        },
        {
            "endpoint": "/public/from_a_file/second/{{.futurama.bender}}",
            "backend": [
                {
                    "url_pattern": "/static/hotels/1.json"
                }
            ]
        }
    ]
}

```

Since krakend cannot scan a folder and automatically add refs, we need to put into settings a list of the files that contains endpoints, and the number of endpoints it contains (this can be generated with an script, as the one provided at the end).

So, we want to have some settings file like this: 

```json
{
  "gatherendpoints": [
    {
      "name": "ref_collection_a.json",
      "num": 2
    },
    {
      "name": "ref_collection_b.json",
      "num": 3
    }
  ]
}
```

and in the endpoints definitions we can use a template block like this one:

```
 "endpoints": [
      {{ range .gatherendpoints }}
          {{$filename := .name}}

          {{ range $n, $k := until (int .num) }}
          {
            "$ref": "./templates/{{ $filename }}#/endpoints/{{ $n }}"
          }
          ,
          {{ end }}
      {{ end }}
      {{ template "endpoints_req_resp_transformations.json" . }},
      {{ template "endpoints_authentication.json" . }},
      {{ template "endpoints_traffic_management.json" . }},
      {{ template "endpoints_services_connectivity.json" . }}
  ],
```
:warning: be careful with the `,` above, because if in the block there is only the `range` block, the last element should not be followed by a `,` 

Check the PR for more details files to have a more detailed view, and an example of gathering endopoints from a couple of files.


Script to gather the file names, and the number of endpoints they have defined inside:
```bash
#/bin/bash

export ENDPOINTS_FOLDER=./
export OUTPUT_FILE=./output.json

echo -e '{\n  "endpoints": [' > $OUTPUT_FILE

export COMMA='    '

# TODO: change here the pattern of the files you want to use:
for FILE in $ENDPOINTS_FOLDER/*.json; do 
    export NUM=$(cat $FILE | jq --raw-output '.endpoints | length')
    export F=$(echo -n "$FILE" | sed 's/\.\/\///g')
    if [ -n "${NUM}" ]; then
        echo -n "$COMMA" >> $OUTPUT_FILE
        export COMMA='   ,'
        echo -n '{ "name": "' >> $OUTPUT_FILE 
        echo -n "$F" >> $OUTPUT_FILE
        echo -n '", "num": "' >> $OUTPUT_FILE
        echo -n "$NUM" >> $OUTPUT_FILE
        echo '"}' >> $OUTPUT_FILE
    fi
done

echo -e "  ]\n}" >> $OUTPUT_FILE

```