### PR TITLE
example of custom cache for the jwk aggregator response

### DIFF
--- a/config/krakend/krakend.json
+++ b/config/krakend/krakend.json
@@ -652,6 +652,30 @@
               "encoding":"no-op"
           }
       ]
+  },
+  {
+      "@comment": "EE only feature: Proxied / Cached JWK Aggregator",
+      "endpoint": "/jwk_cached_aggregator",
+      "output_encoding": "no-op",
+      "backend":[
+          {
+              "host": ["http://localhost:7913"],
+              "url_pattern": "/",
+              "extra_config": {
+                  "qos/http-cache": {
+                      "shared": true
+                  },
+                  "modifier/martian": { 
+                      "header.Modifier": {
+                          "scope": ["response"],
+                          "name": "Cache-Control",
+                          "value": "max-age=300, public"
+                      }
+                  }
+              },
+              "encoding":"no-op"
+          }
+      ]
   }
   ],
   "sequential_start": true,
@@ -740,9 +764,18 @@
     },
     "plugin/http-server": {
       "name": [
+        "jwk-aggregator",
         "geoip",
         "url-rewrite"
       ],
+      "jwk-aggregator": {
+        "port": 7913,
+        "cache": true,
+        "origins": [
+            "https://albert-test.auth0.com/.well-known/jwks.json",
+            "http://localhost:8080/static/jwk/symmetric.json"
+        ]
+      },
       "geoip": {
         "citydb_path": "./geoip/GeoLite2-City.mmdb"
       },


### PR DESCRIPTION
## Example of custom cache for the jwk aggregator response

Sometimes external JWK providers do not provide a `Cache-Control` header, and in that case, the `jwk-aggregator`, when queried does not know for how long it cache the providers response, rendering the `cache: true` option useless (as it does not know for how long to cache ther providers responses). 

In order to not hammer the 3rd party provider, we can cache the plugin jwk service, by proxying it through an endpoint.
